### PR TITLE
simplified mythril version 1.0.0 is working woohooo!!!!!!!

### DIFF
--- a/mythril_clone/mythril/mythril/interfaces/cli.py
+++ b/mythril_clone/mythril/mythril/interfaces/cli.py
@@ -253,18 +253,7 @@ def main() -> None:
     )
 
     subparsers = parser.add_subparsers(dest="command", help="Commands")
-    safe_function_parser = subparsers.add_parser(
-        SAFE_FUNCTIONS_COMMAND,
-        help="Check functions which are completely safe using symbolic execution",
-        parents=[
-            rpc_parser,
-            utilities_parser,
-            creation_input_parser,
-            runtime_input_parser,
-            output_parser,
-        ],
-        formatter_class=RawTextHelpFormatter,
-    )
+    
     analyzer_parser = subparsers.add_parser(
         ANALYZE_LIST[0],
         help="Triggers the analysis of the smart contract",
@@ -278,73 +267,8 @@ def main() -> None:
         aliases=ANALYZE_LIST[1:],
         formatter_class=RawTextHelpFormatter,
     )
-    create_safe_functions_parser(safe_function_parser)
     create_analyzer_parser(analyzer_parser)
-
-    disassemble_parser = subparsers.add_parser(
-        DISASSEMBLE_LIST[0],
-        help="Disassembles the smart contract",
-        aliases=DISASSEMBLE_LIST[1:],
-        parents=[
-            rpc_parser,
-            utilities_parser,
-            creation_input_parser,
-            runtime_input_parser,
-        ],
-        formatter_class=RawTextHelpFormatter,
-    )
-    create_disassemble_parser(disassemble_parser)
-
-    concolic_parser = subparsers.add_parser(
-        CONCOLIC_LIST[0],
-        help="Runs concolic execution to flip the desired branches",
-        aliases=CONCOLIC_LIST[1:],
-        parents=[],
-        formatter_class=RawTextHelpFormatter,
-    )
-    create_concolic_parser(concolic_parser)
-
-    foundry_parser = subparsers.add_parser(
-        FOUNDRY_LIST[0],
-        help="Triggers the analysis of the smart contract",
-        parents=[
-            rpc_parser,
-            utilities_parser,
-            output_parser,
-        ],
-        aliases=FOUNDRY_LIST[1:],
-        formatter_class=RawTextHelpFormatter,
-    )
-
-    _ = subparsers.add_parser(
-        LIST_DETECTORS_COMMAND,
-        parents=[output_parser],
-        help="Lists available detection modules",
-    )
-    read_storage_parser = subparsers.add_parser(
-        READ_STORAGE_COMNAND,
-        help="Retrieves storage slots from a given address through rpc",
-        parents=[rpc_parser],
-    )
-    contract_func_to_hash = subparsers.add_parser(
-        FUNCTION_TO_HASH_COMMAND, help="Returns the hash signature of the function"
-    )
-    contract_hash_to_addr = subparsers.add_parser(
-        HASH_TO_ADDRESS_COMMAND,
-        help="converts the hashes in the blockchain to ethereum address",
-    )
-    subparsers.add_parser(
-        VERSION_COMMAND, parents=[output_parser], help="Outputs the version"
-    )
-
-    create_read_storage_parser(read_storage_parser)
-    create_hash_to_addr_parser(contract_hash_to_addr)
-    create_func_to_hash_parser(contract_func_to_hash)
-    create_foundry_parser(foundry_parser)
-    subparsers.add_parser(HELP_COMMAND, add_help=False)
-
     # Get config values
-
     args = parser.parse_args()
     parse_args_and_execute(parser=parser, args=args)
 
@@ -753,13 +677,7 @@ def execute_command(
             transaction_count=args.transaction_count,
         )
 
-        outputs = {
-            "json": report.as_json(),
-            "jsonv2": report.as_swc_standard_format(),
-            "text": report.as_text(),
-            "markdown": report.as_markdown(),
-        }
-        print(outputs[args.outform])
+        print(report.as_text())
         if len(report.issues) > 0:
             exit(1)
         else:

--- a/mythril_clone/mythril/simplified_mythril.py
+++ b/mythril_clone/mythril/simplified_mythril.py
@@ -1,4 +1,5 @@
 try:
+    """parse args and execute"""
     #instancia de MythrilDisassembler
     disassembler = MythrilDisassembler(
         eth=None,
@@ -12,7 +13,7 @@ try:
         args.solidity_files
     )  # list of files
 
-    execute_command(
-        disassembler=disassembler, address=address, parser=parser, args=args
-    )
+    """execute command"""
+
+    
 

--- a/mythril_clone/mythril/simplified_mythril.py
+++ b/mythril_clone/mythril/simplified_mythril.py
@@ -1,19 +1,89 @@
-try:
-    """parse args and execute"""
-    #instancia de MythrilDisassembler
-    disassembler = MythrilDisassembler(
-        eth=None,
-        solc_version=None,
-        solc_settings_json=None,
-        solc_args=None,
-    )
 
-    # address = '0x0000000000000000000000000000000000000000' _ = [<mythril.solidity.soliditycontract.SolidityContract object at 0x7fe89273f070>]
-    address, _ = disassembler.load_from_solidity(
-        args.solidity_files
-    )  # list of files
+import argparse
+from sys import exit
+from mythril.interfaces.cli import ANALYZE_LIST, create_analyzer_parser, get_creation_input_parser, get_output_parser, get_rpc_parser, get_runtime_input_parser, get_utilities_parser
+from mythril.mythril.mythril_analyzer import MythrilAnalyzer
+from mythril.mythril.mythril_disassembler import MythrilDisassembler
 
-    """execute command"""
+def main() -> None:
+    try:    
+        """The main CLI interface entry point."""
+
+        rpc_parser = get_rpc_parser()
+        utilities_parser = get_utilities_parser()
+        runtime_input_parser = get_runtime_input_parser()
+        creation_input_parser = get_creation_input_parser()
+        output_parser = get_output_parser()
+
+        parser = argparse.ArgumentParser(
+            description="Security analysis of Ethereum smart contracts"
+        )
+        parser.add_argument("--epic", action="store_true", help=argparse.SUPPRESS)
+        parser.add_argument(
+            "-v", type=int, help="log level (0-5)", metavar="LOG_LEVEL", default=2
+        )
+
+        subparsers = parser.add_subparsers(dest="command", help="Commands")
+        
+        analyzer_parser = subparsers.add_parser(
+            ANALYZE_LIST[0],
+            help="Triggers the analysis of the smart contract",
+            parents=[
+                rpc_parser,
+                utilities_parser,
+                creation_input_parser,
+                runtime_input_parser,
+                output_parser,
+            ],
+            aliases=ANALYZE_LIST[1:],
+            formatter_class=argparse.RawTextHelpFormatter,
+        )
+        create_analyzer_parser(analyzer_parser)
+        # Get config values
+        args = parser.parse_args()
+
+        """parse args and execute --------------------------------------------"""
+        #instancia de MythrilDisassembler
+        disassembler = MythrilDisassembler(
+            eth=None,
+            solc_version=None,
+            solc_settings_json=None,
+            solc_args=None,
+        )
+
+        # address = '0x0000000000000000000000000000000000000000' _ = [<mythril.solidity.soliditycontract.SolidityContract object at 0x7fe89273f070>]
+        address, _ = disassembler.load_from_solidity(
+            args.solidity_files
+        )  # list of files
+
+        """execute command --------------------------------------------"""
+
+        strategy = getattr(args, "strategy", "dfs")
+        analyzer = MythrilAnalyzer(
+            strategy=strategy, disassembler=disassembler, address=address, cmd_args=args
+        )
 
     
+        report = analyzer.fire_lasers(
+            modules=(
+                [m.strip() for m in args.modules.strip().split(",")]
+                if args.modules
+                else None
+            ),
+            transaction_count=args.transaction_count,
+        )
+        
+        print(report.as_text())
+        if len(report.issues) > 0:
+            exit(1)
+        else:
+            exit(0)      
+    except Exception as e:
+        print(f"Error during analysis: {str(e)}")
 
+
+
+
+if __name__ == "__main__":
+    main()
+    exit()


### PR DESCRIPTION
This pull request refactors the CLI interface for the Mythril tool by removing several command parsers and simplifying the command execution logic. The changes focus on streamlining the code and making it more maintainable.

### Refactoring and Simplification:

* Removed multiple command parsers (`safe_function_parser`, `disassemble_parser`, `concolic_parser`, `foundry_parser`, and others) from the `main` function in `mythril_clone/mythril/mythril/interfaces/cli.py`, consolidating the remaining functionality into fewer parsers. [[1]](diffhunk://#diff-6cef77a4e6bf95c63e4f6841d2f91d3c2fe4d301b6bb1afec3ebd687d8934058L256-R256) [[2]](diffhunk://#diff-6cef77a4e6bf95c63e4f6841d2f91d3c2fe4d301b6bb1afec3ebd687d8934058L281-L347)
* Simplified the `execute_command` function by removing the handling of several specific commands and reducing the output formats to just text. [[1]](diffhunk://#diff-6cef77a4e6bf95c63e4f6841d2f91d3c2fe4d301b6bb1afec3ebd687d8934058L741-L833) [[2]](diffhunk://#diff-6cef77a4e6bf95c63e4f6841d2f91d3c2fe4d301b6bb1afec3ebd687d8934058L844-R680) [[3]](diffhunk://#diff-6cef77a4e6bf95c63e4f6841d2f91d3c2fe4d301b6bb1afec3ebd687d8934058L862-R692)

### New Simplified CLI:

* Introduced a new simplified CLI entry point in `mythril_clone/mythril/simplified_mythril.py`, which includes only the essential command parsing and execution logic. [[1]](diffhunk://#diff-4b125ec56171047bf0a228a26aefc5af359ab79df66cf3b0dee856ad45c7333eR1-R45) [[2]](diffhunk://#diff-4b125ec56171047bf0a228a26aefc5af359ab79df66cf3b0dee856ad45c7333eL15-R89)